### PR TITLE
Fix blank line when inserting draft

### DIFF
--- a/src/__tests__/gmail.test.js
+++ b/src/__tests__/gmail.test.js
@@ -84,6 +84,19 @@ describe('Gmail utils', () => {
       expect(result).toBe(true);
       expect(editableDiv.textContent).toBe(draftText);
     });
+
+    it('should remove initial <br> placeholder before inserting draft', () => {
+      const composeWindow = document.querySelector('[aria-label="Message Body"]');
+      const editableDiv = composeWindow.querySelector('[contenteditable="true"]');
+      editableDiv.innerHTML = '<br>';
+      editableDiv.dispatchEvent = jest.fn();
+
+      const result = appendDraft(composeWindow, 'Draft');
+
+      expect(result).toBe(true);
+      expect(editableDiv.innerHTML.startsWith('<br>')).toBe(false);
+      expect(editableDiv.textContent).toBe('Draft');
+    });
     
     it('should append draft text after existing content', () => {
       // Set up a compose window with existing content

--- a/src/content.js
+++ b/src/content.js
@@ -175,9 +175,17 @@ function appendDraft(composeWindow, draftText) {
 
     if (!success) {
         console.error('[appendDraft] document.execCommand("insertText") failed. Trying appendChild as fallback...');
+
+        // Remove Gmail's initial <br> placeholder to avoid leading blank line
+        if (editableDiv.childNodes.length === 1 &&
+            editableDiv.childNodes[0].nodeName === 'BR' &&
+            editableDiv.textContent.trim() === '') {
+          editableDiv.innerHTML = '';
+        }
+
         // Fallback to previous appendChild method if execCommand fails
         const fragment = document.createDocumentFragment();
-        const textNode = document.createTextNode(textToInsert); 
+        const textNode = document.createTextNode(textToInsert);
         fragment.appendChild(textNode);
         editableDiv.appendChild(fragment);
         

--- a/src/utils/gmail.js
+++ b/src/utils/gmail.js
@@ -94,6 +94,13 @@ exports.appendDraft = function(composeWindow, draftText) {
 
     console.log('Found editable area:', editableDiv);
 
+    // Remove Gmail's placeholder <br> if the compose window is otherwise empty
+    if (editableDiv.childNodes.length === 1 &&
+        editableDiv.childNodes[0].nodeName === 'BR' &&
+        editableDiv.textContent.trim() === '') {
+      editableDiv.innerHTML = '';
+    }
+
     // Check if there's existing content
     const hasExistingContent = editableDiv.textContent.trim().length > 0;
     


### PR DESCRIPTION
## Summary
- clear Gmail's `<br>` placeholder before appending draft text
- test for removing initial `<br>` placeholder

## Testing
- `npm test` *(fails: TypeError cannot read properties of undefined (reading 'addListener'))*