### PR TITLE
Fix Gmail placeholder removal

### DIFF
--- a/src/__tests__/gmail.test.js
+++ b/src/__tests__/gmail.test.js
@@ -84,6 +84,32 @@ describe('Gmail utils', () => {
       expect(result).toBe(true);
       expect(editableDiv.textContent).toBe(draftText);
     });
+
+    it('should remove initial <br> placeholder before inserting draft', () => {
+      const composeWindow = document.querySelector('[aria-label="Message Body"]');
+      const editableDiv = composeWindow.querySelector('[contenteditable="true"]');
+      editableDiv.innerHTML = '<br>';
+      editableDiv.dispatchEvent = jest.fn();
+
+      const result = appendDraft(composeWindow, 'Draft');
+
+      expect(result).toBe(true);
+      expect(editableDiv.innerHTML.startsWith('<br>')).toBe(false);
+      expect(editableDiv.textContent).toBe('Draft');
+    });
+
+    it('should remove nested <div><br></div> placeholder before inserting draft', () => {
+      const composeWindow = document.querySelector('[aria-label="Message Body"]');
+      const editableDiv = composeWindow.querySelector('[contenteditable="true"]');
+      editableDiv.innerHTML = '<div><br></div>';
+      editableDiv.dispatchEvent = jest.fn();
+
+      const result = appendDraft(composeWindow, 'Draft');
+
+      expect(result).toBe(true);
+      expect(editableDiv.innerHTML.startsWith('<div><br></div>')).toBe(false);
+      expect(editableDiv.textContent).toBe('Draft');
+    });
     
     it('should append draft text after existing content', () => {
       // Set up a compose window with existing content

--- a/src/content.js
+++ b/src/content.js
@@ -175,9 +175,16 @@ function appendDraft(composeWindow, draftText) {
 
     if (!success) {
         console.error('[appendDraft] document.execCommand("insertText") failed. Trying appendChild as fallback...');
+
+        // Remove Gmail's placeholder HTML (e.g., <br> or <div><br></div>)
+        // if the compose area is otherwise empty to avoid a leading blank line
+        if (editableDiv.textContent.trim() === '') {
+          editableDiv.innerHTML = '';
+        }
+
         // Fallback to previous appendChild method if execCommand fails
         const fragment = document.createDocumentFragment();
-        const textNode = document.createTextNode(textToInsert); 
+        const textNode = document.createTextNode(textToInsert);
         fragment.appendChild(textNode);
         editableDiv.appendChild(fragment);
         

--- a/src/utils/gmail.js
+++ b/src/utils/gmail.js
@@ -94,6 +94,12 @@ exports.appendDraft = function(composeWindow, draftText) {
 
     console.log('Found editable area:', editableDiv);
 
+    // Remove Gmail's placeholder HTML (e.g., <br> or <div><br></div>) if the
+    // compose window is otherwise empty to avoid a leading blank line
+    if (editableDiv.textContent.trim() === '') {
+      editableDiv.innerHTML = '';
+    }
+
     // Check if there's existing content
     const hasExistingContent = editableDiv.textContent.trim().length > 0;
     


### PR DESCRIPTION
## Summary
- handle nested Gmail placeholder when appending draft text
- update gmail utilities to mirror same logic
- test nested `<div><br></div>` placeholders

## Testing
- `npm test` *(fails: TypeError cannot read properties of undefined)*